### PR TITLE
Fix i2c address property name in example codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const delay = millis => new Promise(resolve => setTimeout(resolve, millis));
 const reportContinuous = async _ => {
   const sensor = await bme280.open({
     i2cBusNumber: 1,
-    i2cBusAddress: 0x77,
+    i2cAddress: 0x77,
     humidityOversampling: bme280.OVERSAMPLE.X1,
     pressureOversampling: bme280.OVERSAMPLE.X16,
     temperatureOversampling: bme280.OVERSAMPLE.X2,

--- a/examples/read-gaming.js
+++ b/examples/read-gaming.js
@@ -13,7 +13,7 @@ const delay = millis => new Promise(resolve => setTimeout(resolve, millis));
 const reportContinuous = async _ => {
   const sensor = await bme280.open({
     i2cBusNumber: 1,
-    i2cBusAddress: 0x77,
+    i2cAddress: 0x77,
     humidityOversampling: bme280.OVERSAMPLE.SKIPPED,
     pressureOversampling: bme280.OVERSAMPLE.X4,
     temperatureOversampling: bme280.OVERSAMPLE.X1,

--- a/examples/read-indoor-navigation.js
+++ b/examples/read-indoor-navigation.js
@@ -13,7 +13,7 @@ const delay = millis => new Promise(resolve => setTimeout(resolve, millis));
 const reportContinuous = async _ => {
   const sensor = await bme280.open({
     i2cBusNumber: 1,
-    i2cBusAddress: 0x77,
+    i2cAddress: 0x77,
     humidityOversampling: bme280.OVERSAMPLE.X1,
     pressureOversampling: bme280.OVERSAMPLE.X16,
     temperatureOversampling: bme280.OVERSAMPLE.X2,


### PR DESCRIPTION
Property `i2cBusAddress` specifies the address in the sample code is not used in the actual code, it should be `i2cAddress`

The library just output Remote I/O error, so I took 2 hours for identify the cause ;D
